### PR TITLE
Update validation for event id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ neardev
 /node_modules
 /build
 
+.idea/
+
 # debug
 npm-debug.log*
 yarn-debug.log*

--- a/assembly/index.ts
+++ b/assembly/index.ts
@@ -16,10 +16,9 @@ export function addEvent(title:string, description:string, location:string, date
 //reading a specific event detail
 export function getEvent(id: i32): MeetingUnit{
     // validate id input
-    assert(typeof(id) === "number" ,"Invalid input, id type must be number");
+    assert(id < availableMeetups.length, "Invalid input, id not exists");
 
-    const result = availableMeetups[i32(id)];  //fetching an existing meetup id from the existing collection
-    return result;
+    return availableMeetups[i32(id)];  //fetching an existing meetup id from the existing collection
 }
 
 //reading all available meetups

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build:contract": "asb",
     "build:contract:debug": "asb --target debug",
     "deploy": "yarn build && near deploy",
-    "dev": "yarn build:contract:debug && near dev-deploy",
+    "dev": "yarn build:contract:debug && near dev-deploy ./build/debug/near-meetups.wasm",
     "test": "yarn build:contract:debug && asp"
   },
   "devDependencies": {


### PR DESCRIPTION
**assembly/index.ts**
Updated validation for getEvent method. Previous validation check by type, but id always is number (in other case alweys return error). Additionally we should check if this id exists.

**package.json**
Updated "dev" script. In other case command "dev-deploy" try to deploy default path that is "out/main.wasm"